### PR TITLE
Change image to debian and bump neo4j version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM openjdk:11-jre-slim
+FROM debian:stable-slim
 LABEL org.opencontainers.image.authors="https://github.com/belane" \
       org.opencontainers.image.description="BloodHound Docker Ready to Use" \
       org.opencontainers.image.source="https://github.com/belane/docker-bloodhound" \
       org.opencontainers.image.title="docker-bloodhound" \
       org.opencontainers.image.version="0.2.0"
-ARG neo4j=4.4.10
-ARG bloodhound=4.2.0
+ARG bloodhound=4.0.3
 
 # Base packages
 RUN apt-get update -qq &&\
@@ -24,13 +23,14 @@ RUN apt-get update -qq &&\
       libgl1-mesa-dri \
       libgconf-2-4 \
       libasound2 \
-      libxss1
+      libxss1 \
+      openjdk-17-jre
 
 # Neo4j
 RUN wget -nv -O - https://debian.neo4j.com/neotechnology.gpg.key | apt-key add - &&\
     echo 'deb https://debian.neo4j.com stable latest' | tee /etc/apt/sources.list.d/neo4j.list &&\
     apt-get update &&\ 
-    apt-get install -y -qq neo4j=1:$neo4j
+    apt-get install -y -qq neo4j
 
 # BloodHound
 RUN wget https://github.com/BloodHoundAD/BloodHound/releases/download/$bloodhound/BloodHound-linux-x64.zip -nv -P /tmp &&\
@@ -46,7 +46,7 @@ RUN wget https://raw.githubusercontent.com/CompassSecurity/BloodHoundQueries/mas
 
 # Init Script
 RUN echo '#!/usr/bin/env bash\n\
-    neo4j-admin set-initial-password blood \n\
+    neo4j-admin dbms set-initial-password blood \n\
     service neo4j start\n\
     cp -n /opt/BloodHound-linux-x64/resources/app/Collectors/SharpHound.* /data\n\
     echo "\e[92m*** Log in with bolt://127.0.0.1:7687 (neo4j:blood) ***\e[0m"\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ LABEL org.opencontainers.image.authors="https://github.com/belane" \
       org.opencontainers.image.source="https://github.com/belane/docker-bloodhound" \
       org.opencontainers.image.title="docker-bloodhound" \
       org.opencontainers.image.version="0.2.0"
-ARG bloodhound=4.0.3
+ARG neo4j=4.4.15
+ARG bloodhound=4.2.0
 
 # Base packages
 RUN apt-get update -qq &&\
@@ -24,13 +25,14 @@ RUN apt-get update -qq &&\
       libgconf-2-4 \
       libasound2 \
       libxss1 \
-      openjdk-17-jre
+      apt-transport-https \
+      openjdk-11-jre
 
 # Neo4j
 RUN wget -nv -O - https://debian.neo4j.com/neotechnology.gpg.key | apt-key add - &&\
-    echo 'deb https://debian.neo4j.com stable latest' | tee /etc/apt/sources.list.d/neo4j.list &&\
-    apt-get update &&\ 
-    apt-get install -y -qq neo4j
+    echo 'deb https://debian.neo4j.com stable 4.4' | tee /etc/apt/sources.list.d/neo4j.list &&\
+    apt-get update &&\
+    apt-get install -y -qq neo4j=1:$neo4j
 
 # BloodHound
 RUN wget https://github.com/BloodHoundAD/BloodHound/releases/download/$bloodhound/BloodHound-linux-x64.zip -nv -P /tmp &&\
@@ -46,7 +48,7 @@ RUN wget https://raw.githubusercontent.com/CompassSecurity/BloodHoundQueries/mas
 
 # Init Script
 RUN echo '#!/usr/bin/env bash\n\
-    neo4j-admin dbms set-initial-password blood \n\
+    neo4j-admin set-initial-password blood \n\
     service neo4j start\n\
     cp -n /opt/BloodHound-linux-x64/resources/app/Collectors/SharpHound.* /data\n\
     echo "\e[92m*** Log in with bolt://127.0.0.1:7687 (neo4j:blood) ***\e[0m"\n\

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # BloodHound Docker Ready to Use
 
+## Fork Details
+This fork is made to use the latest debian:stable-slim docker image and install the required dependencies for Bloodhound 4.0.3. This change is made to support Sharphound3 files which is still useful, particularly in CTFs where a current .NET install may not be available. 
+
 [BloodHound](https://github.com/BloodHoundAD/BloodHound) Docker image out of the box, with collectors and [tons of custom queries](https://github.com/CompassSecurity/BloodHoundQueries/blob/master/customqueries.json). It creates a `bh-data` folder with the Ingestors, the data folder is also mounted as a volume, use this to drop your data and load it into the BloodHound GUI.
 
 ![bloodhound](https://user-images.githubusercontent.com/17031267/48985201-6f587a00-f105-11e8-8355-98e38e08cc5e.png)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # BloodHound Docker Ready to Use
 
-## Fork Details
-This fork is made to use the latest debian:stable-slim docker image and install the required dependencies for Bloodhound 4.0.3. This change is made to support Sharphound3 files which is still useful, particularly in CTFs where a current .NET install may not be available. 
-
 [BloodHound](https://github.com/BloodHoundAD/BloodHound) Docker image out of the box, with collectors and [tons of custom queries](https://github.com/CompassSecurity/BloodHoundQueries/blob/master/customqueries.json). It creates a `bh-data` folder with the Ingestors, the data folder is also mounted as a volume, use this to drop your data and load it into the BloodHound GUI.
 
 ![bloodhound](https://user-images.githubusercontent.com/17031267/48985201-6f587a00-f105-11e8-8355-98e38e08cc5e.png)


### PR DESCRIPTION
This simple pull request changes the image to debian:stable-slim and bumps the neo4j version to 4.4.15 (avoiding 5.0 because of https://github.com/BloodHoundAD/BloodHound/issues/607).

I haven't done extensive testing, but it builds and runs fine on my machine. A future PR should be made to remove the deprecated `apt-key add - ` command.